### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/events/logger/logger.go
+++ b/events/logger/logger.go
@@ -142,6 +142,12 @@ func processHeaders(hide bool, headers http.Header) http.Header {
 	headers = headers.Clone()
 	sensitiveHeaders := []string{
 		"Authorization",
+		"Cookie",
+		"Set-Cookie",
+		"Proxy-Authorization",
+		"X-Api-Key",
+		"X-Amz-Security-Token",
+		"X-Amz-User-Agent",
 	}
 	for _, header := range sensitiveHeaders {
 		if headers.Get(header) != "" {


### PR DESCRIPTION
Potential fix for [https://github.com/pwnlaboratory/nordvpn-linux/security/code-scanning/3](https://github.com/pwnlaboratory/nordvpn-linux/security/code-scanning/3)

To fix the problem, we need to ensure that sensitive information is always obfuscated or omitted before being logged. This can be achieved by enhancing the `processHeaders` function to handle more sensitive headers and by ensuring that the `hideSensitiveHeaders` flag is always set to `true` when calling `dataRequestAPIToString`. Additionally, we should review other logging functions to ensure they do not inadvertently log sensitive information.

1. Enhance the `processHeaders` function to handle more sensitive headers.
2. Ensure the `hideSensitiveHeaders` flag is always set to `true` when calling `dataRequestAPIToString`.
3. Review other logging functions to ensure they do not log sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
