### PR TITLE
Potential fix for code scanning alert no. 8: Incorrect conversion between integer types

### DIFF
--- a/cmd/norduser/main.go
+++ b/cmd/norduser/main.go
@@ -257,11 +257,12 @@ func startSnap() {
 		log.Println(internal.ErrorPrefix, "Failed to add autostart:", err)
 	}
 
-	uid, err := strconv.Atoi(usr.Uid)
+	uid64, err := strconv.ParseUint(usr.Uid, 10, 32)
 	if err != nil {
 		log.Printf("%s Invalid unix user id, failed to convert from string: %s", internal.ErrorPrefix, usr.Uid)
 		os.Exit(int(childprocess.CodeFailedToEnable))
 	}
+	uid := uint32(uid64)
 
 	logoutChan := make(chan interface{})
 	go func() {


### PR DESCRIPTION
Potential fix for [https://github.com/pwnlaboratory/nordvpn-linux/security/code-scanning/8](https://github.com/pwnlaboratory/nordvpn-linux/security/code-scanning/8)

To fix the problem, we need to ensure that the integer value parsed from the string does not exceed the bounds of the `uint32` type. This can be achieved by using `strconv.ParseUint` with a specified bit size of 32, which directly parses the string into a `uint32` value. This approach avoids the need for additional bounds checking and ensures that the value is within the valid range for a `uint32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
